### PR TITLE
Fail fast when relaunched process exits without showing a window

### DIFF
--- a/main.go
+++ b/main.go
@@ -824,6 +824,15 @@ func main() {
 		}
 	}
 
+	// If -path was supplied explicitly and -name was not overridden, sync *name
+	// from the exe basename so that waitForWindow and isRunning check the correct
+	// image name instead of the default "U.GG.exe".
+	if exePath != "" && *name == defaultProcessName {
+		if base := strings.ToLower(filepath.Base(exePath)); base != "" {
+			*name = base
+		}
+	}
+
 	// In GUI mode: start the live window immediately after path is resolved,
 	// before any long-running work begins.
 	if autoPopup {
@@ -896,7 +905,7 @@ func main() {
 	}
 	// Wait until U.GG's window is actually visible on screen before reporting done.
 	if !waitForWindow(*name, 30*time.Second) && !isRunning(*name) {
-		fail("U.GG exited unexpectedly after launch")
+		fail("%s exited unexpectedly after launch", *name)
 	}
 	out("done")
 	prog.Starting = "done"

--- a/main.go
+++ b/main.go
@@ -616,7 +616,8 @@ func waitForExit(processName string, timeout time.Duration) bool {
 
 // waitForWindow runs a single hidden PowerShell process that polls internally
 // until any instance of the named process has a visible main window, or until
-// the timeout expires. One process, no flash loop.
+// the timeout expires. Returns false immediately if the process exits without
+// ever showing a window (e.g. crashed on launch). One process, no flash loop.
 func waitForWindow(processName string, timeout time.Duration) bool {
 	psName := strings.TrimSuffix(processName, ".exe")
 	secs := int(timeout.Seconds())
@@ -624,6 +625,7 @@ func waitForWindow(processName string, timeout time.Duration) bool {
 		`$n=[regex]::Escape('%s'); $end=(Get-Date).AddSeconds(%d); `+
 			`while ((Get-Date) -lt $end) { `+
 			`if (Get-Process -EA SilentlyContinue | Where-Object { $_.ProcessName -match ('(?i)^'+$n) -and $_.MainWindowHandle -ne 0 }) { exit 0 }; `+
+			`if (-not (Get-Process -EA SilentlyContinue | Where-Object { $_.ProcessName -match ('(?i)^'+$n) })) { exit 2 }; `+
 			`Start-Sleep -Milliseconds 500 }; exit 1`,
 		psSingleQuote(psName), secs,
 	)
@@ -893,7 +895,9 @@ func main() {
 		fail("launch failed: %v", err)
 	}
 	// Wait until U.GG's window is actually visible on screen before reporting done.
-	waitForWindow(*name, 30*time.Second)
+	if !waitForWindow(*name, 30*time.Second) && !isRunning(*name) {
+		fail("U.GG exited unexpectedly after launch")
+	}
 	out("done")
 	prog.Starting = "done"
 	updateProgress()


### PR DESCRIPTION
﻿`waitForWindow` previously had no mechanism to detect whether the target process was still alive. If U.GG crashed immediately after launch, the tool would hang silently for the full 30-second timeout before continuing.

**Changes:**
- The PowerShell polling loop now also checks if the process is still running. If it exits without ever showing a window, the loop exits immediately (`exit 2`) instead of waiting out the full timeout.
- The call site in `main` now checks the return value: if `waitForWindow` returns `false` **and** the process is no longer running, `fail()` is called with a descriptive error message.

Fixes #3