### PR TITLE
Use PID-based temp file names to prevent concurrent instance collision

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func liveWindowXAML() string {
 // that polls statusFile every 250ms, animating steps in as they complete.
 // Returns immediately; the window stays open until the user clicks Close.
 func showLiveWindow(statusFile, logPath string) {
-	xamlPath := filepath.Join(os.TempDir(), "ugg-memory-wrangler-ui.xaml")
+	xamlPath := filepath.Join(os.TempDir(), fmt.Sprintf("ugg-memory-wrangler-%d-ui.xaml", os.Getpid()))
 	if err := os.WriteFile(xamlPath, []byte(liveWindowXAML()), 0o644); err != nil {
 		return
 	}
@@ -825,7 +825,7 @@ func main() {
 	// In GUI mode: start the live window immediately after path is resolved,
 	// before any long-running work begins.
 	if autoPopup {
-		progressFile = filepath.Join(os.TempDir(), "ugg-memory-wrangler-progress.json")
+		progressFile = filepath.Join(os.TempDir(), fmt.Sprintf("ugg-memory-wrangler-%d-progress.json", os.Getpid()))
 		writeProgress(progressFile, progressState{Status: "working"})
 		showLiveWindow(progressFile, logPath)
 	}


### PR DESCRIPTION
﻿Both temp files written during a GUI-mode run previously used fixed names:

- `%TEMP%\ugg-memory-wrangler-ui.xaml`
- `%TEMP%\ugg-memory-wrangler-progress.json`

A second instance launched while the first was still running would overwrite both files, corrupting the live-progress window of the first run.

Both names now embed the process ID (e.g. `ugg-memory-wrangler-12345-progress.json`), giving each run fully isolated temp files.

Fixes #4