### PR TITLE
Surface appendLog errors instead of silently discarding them

### DIFF
--- a/main.go
+++ b/main.go
@@ -947,7 +947,13 @@ func main() {
 		}
 	}
 
-	_ = appendLog(logPath, *name, beforeBytes, afterBytes, freedBytes)
+	if logErr := appendLog(logPath, *name, beforeBytes, afterBytes, freedBytes); logErr != nil {
+		if !autoPopup {
+			fmt.Fprintf(os.Stderr, "  warning: could not write to log: %v\n", logErr)
+		} else {
+			prog.Message = fmt.Sprintf("Warning: could not write to log: %v", logErr)
+		}
+	}
 
 	// Console summary (CLI only)
 	out("  " + strings.Repeat("─", 36))


### PR DESCRIPTION
﻿`appendLog` errors (disk full, permission denied, bad path, etc.) were previously discarded with `_ =`. Run data could be silently lost with no indication to the user.

- **CLI mode**: the error is now printed to stderr as a warning.
- **GUI mode**: the error is set as the progress window's `message` field, so it appears in red in the live-progress window when the run completes.

Fixes #5