### PR TITLE
Escape regex metacharacters in getExePathByKeyword

### DIFF
--- a/main.go
+++ b/main.go
@@ -382,7 +382,7 @@ func getExePathByKeyword(keyword string) string {
 		return ""
 	}
 	cmd := fmt.Sprintf(
-		`$p=(Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Path -and $_.ProcessName -match '(?i)%s' } | Select-Object -First 1 -ExpandProperty Path); if ($p) { $p }`,
+		`$k=[regex]::Escape('%s'); $p=(Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Path -and $_.ProcessName -match ('(?i)'+$k) } | Select-Object -First 1 -ExpandProperty Path); if ($p) { $p }`,
 		psSingleQuote(keyword),
 	)
 	out, err := hiddenCmd(


### PR DESCRIPTION
﻿`getExePathByKeyword` embedded the process name keyword directly into a PowerShell `-match` pattern without escaping. `psSingleQuote` only escapes the single-quote character for PowerShell string safety — it does not escape regex metacharacters.

The default keyword `u.gg` contains a literal dot (`.`), which in a regex matches any character. This could cause the function to return the path of an unintended process (e.g. one named `uXgg`).

The fix assigns `[regex]::Escape(keyword)` to a variable before using it in `-match`, consistent with the existing pattern in `waitForWindow` and `getProcessMemoryBytes`.

Fixes #6