### PR TITLE
Warn and recover when metrics.json is unreadable or corrupt

### DIFF
--- a/main.go
+++ b/main.go
@@ -932,19 +932,23 @@ func main() {
 		}
 	}
 
-	m, err := loadMetrics(metricsPath)
-	if err == nil {
-		m.Runs++
-		m.LastFreedBytes = freedBytes
-		m.LastBeforeBytes = beforeBytes
-		if freedBytes > 0 {
-			m.TotalFreedBytes += freedBytes
+	m, metricsErr := loadMetrics(metricsPath)
+	if metricsErr != nil {
+		if !autoPopup {
+			fmt.Fprintf(os.Stderr, "  warning: could not read metrics, resetting: %v\n", metricsErr)
 		}
-		m.UpdatedAt = time.Now().Format(time.RFC3339)
-		if saveErr := saveMetrics(metricsPath, m); saveErr == nil {
-			lifetimeTotalBytes = m.TotalFreedBytes
-			lifetimeRuns = m.Runs
-		}
+		m = metrics{}
+	}
+	m.Runs++
+	m.LastFreedBytes = freedBytes
+	m.LastBeforeBytes = beforeBytes
+	if freedBytes > 0 {
+		m.TotalFreedBytes += freedBytes
+	}
+	m.UpdatedAt = time.Now().Format(time.RFC3339)
+	if saveErr := saveMetrics(metricsPath, m); saveErr == nil {
+		lifetimeTotalBytes = m.TotalFreedBytes
+		lifetimeRuns = m.Runs
 	}
 
 	_ = appendLog(logPath, *name, beforeBytes, afterBytes, freedBytes)

--- a/main.go
+++ b/main.go
@@ -935,7 +935,10 @@ func main() {
 	m, metricsErr := loadMetrics(metricsPath)
 	if metricsErr != nil {
 		if !autoPopup {
-			fmt.Fprintf(os.Stderr, "  warning: could not read metrics, resetting: %v\n", metricsErr)
+			fmt.Fprintf(os.Stderr, "  warning: could not read metrics, starting fresh this run: %v\n", metricsErr)
+		} else {
+			prog.Message = fmt.Sprintf("Warning: could not read metrics, starting fresh this run: %v", metricsErr)
+			updateProgress()
 		}
 		m = metrics{}
 	}
@@ -949,6 +952,13 @@ func main() {
 	if saveErr := saveMetrics(metricsPath, m); saveErr == nil {
 		lifetimeTotalBytes = m.TotalFreedBytes
 		lifetimeRuns = m.Runs
+	} else {
+		if !autoPopup {
+			fmt.Fprintf(os.Stderr, "  warning: could not save metrics: %v\n", saveErr)
+		} else {
+			prog.Message = fmt.Sprintf("Warning: could not save metrics: %v", saveErr)
+			updateProgress()
+		}
 	}
 
 	_ = appendLog(logPath, *name, beforeBytes, afterBytes, freedBytes)


### PR DESCRIPTION
﻿`loadMetrics` already returns `nil` for `os.IsNotExist` (the normal first-run case), so any non-nil error it returns is genuinely unexpected (corrupt file, permission error, etc.).

The old code guarded the entire metrics block with `if err == nil`, meaning a corrupt `metrics.json` caused the run to go completely unrecorded — no count increment, no freed-bytes accumulation, and no file written — with zero feedback to the user.

**Fix:**
- The error is now surfaced as a warning to stderr in CLI mode.
- The metrics struct is reset to zero and processing continues, so the current run is still counted and a fresh `metrics.json` is written (replacing the corrupt one).

Fixes #7